### PR TITLE
Release 2.4.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to the [flutter-translator extension](https://marketplace.visualstudio.com/items?itemName=DevStory.flutter-translator) will be documented in this file.
 
+## [2.4.2] - 24.03.17
+### Fixed
+- Fix the url files can be selected when translating meatadata.
+
+### Changed
+- Change default cache application to off when text translating.
+
 ## [2.4.1] - 24.03.15
 ### Added
 - Add batch to ARB translation.

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "license": "SEE LICENSE IN LICENSE",
   "displayName": "Flutter Translator",
   "description": "It supports the internationalization of flutter applications using Google Translator.",
-  "version": "2.4.1",
+  "version": "2.4.2",
   "engines": {
     "vscode": "^1.84.0"
   },

--- a/src/app/cmd/translation/text.translate.cmd.ts
+++ b/src/app/cmd/translation/text.translate.cmd.ts
@@ -95,7 +95,7 @@ export class TextTranslateCmd {
           queries,
           sourceLang,
           targetLang,
-          useCache: args?.useCache,
+          useCache: args?.useCache ?? false,
         })
       ).data;
 

--- a/src/app/component/metadata/metadata.service.ts
+++ b/src/app/component/metadata/metadata.service.ts
@@ -257,14 +257,12 @@ export class MetadataService {
     metadata: Metadata
   ): Promise<MetadataText[]> {
     const selections = await vscode.window.showQuickPick(
-      metadata.dataList
-        .filter((data) => data.type === MetadataType.text)
-        .map((data) => ({
-          label: data.fileName,
-          picked: data.text.length > 0,
-          description: `${data.text.length.toLocaleString()} characters`,
-          data,
-        })),
+      metadata.dataList.map((data) => ({
+        label: data.fileName,
+        picked: data.text.length > 0,
+        description: `${data.text.length.toLocaleString()} characters`,
+        data,
+      })),
       {
         title: "Select Files",
         placeHolder: "Select list of files to translate",


### PR DESCRIPTION
- Fix the url files can be selected when translating meatadata.
- Change default cache application to off when text translating.
- Release 2.4.2
